### PR TITLE
Control the LEDs 

### DIFF
--- a/src/Bitcraze_PMW3901.cpp
+++ b/src/Bitcraze_PMW3901.cpp
@@ -265,3 +265,11 @@ void Bitcraze_PMW3901::initRegisters()
   registerWrite(0x5A, 0x50);
   registerWrite(0x40, 0x80);
 }
+
+void Bitcraze_PMW3901::setLed(bool ledOn)
+{
+  delay(200);
+  registerWrite(0x7f, 0x14);
+  registerWrite(0x6f, ledOn ? 0x1c : 0x00);
+  registerWrite(0x7f, 0x00);
+}

--- a/src/Bitcraze_PMW3901.h
+++ b/src/Bitcraze_PMW3901.h
@@ -37,6 +37,8 @@ public:
   void enableFrameBuffer();
   void readFrameBuffer(char *FBuffer);
 
+  void setLed(bool ledOn);
+
 private:
   uint8_t _cs;
 


### PR DESCRIPTION
Added `setLeds` with the code from https://github.com/bitcraze/Bitcraze_PMW3901/issues/12 and https://github.com/pimoroni/pmw3901-python/issues/4

 I tested with Pimoroni's PMW3901 breakout and an Arduino. Simply adding `flow.setLed(true);` to the end of `setup`.